### PR TITLE
[CIR-update-readme-add-script] Update the readme and add script to start services locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,37 +12,54 @@ Run the following commands to start services locally:
     docker run --rm -d -p 27017:27017 --name mongo percona/percona-server-mongodb:5.0
 
     sm2 --start BANK_ACCOUNT_REPUTATION_FRONTEND_SERVICES --appendArgs '{
-     "BANK_ACCOUNT_REPUTATION": [
-     "-J-Dapplication.router=testOnlyDoNotUseInAppConf.Routes",
-     "-J-Dmicroservice.services.callvalidate.endpoint=http://localhost:6001/callvalidateapi",
-     "-J-Dauditing.consumer.baseUri.port=6001",
-     "-J-Dauditing.consumer.baseUri.host=localhost",
-     "-J-Dauditing.enabled=true",
-     "-J-Dproxy.proxyRequiredForThisEnvironment=false",
-     "-J-Dmicroservice.services.eiscd.aws.endpoint=http://localhost:6002",
-     "-J-Dmicroservice.services.eiscd.aws.bucket=txm-dev-bacs-eiscd",
-     "-J-Dmicroservice.services.eiscd.aws.accesskeyid=AKIAIOSFODNN7EXAMPLE",
-     "-J-Dmicroservice.services.eiscd.aws.secretkey=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-     "-J-Dmicroservice.services.modcheck.aws.endpoint=http://localhost:6002",
-     "-J-Dmicroservice.services.thirdPartyCache.endpoint=http://localhost:9899/cache",
-     "-J-Dmicroservice.services.access-control.endpoint.verify.enabled=true",
-     "-J-Dmicroservice.services.access-control.endpoint.verify.allow-list.0=bars-acceptance-tests",
-     "-J-Dmicroservice.services.access-control.endpoint.verify.allow-list.1=some-upstream-service",
-     "-J-Dmicroservice.services.access-control.endpoint.verify.allow-list.2=bank-account-reputation-frontend",
-     "-J-Dmicroservice.services.access-control.endpoint.validate.enabled=true",
-     "-J-Dmicroservice.services.access-control.endpoint.validate.allow-list.0=bars-acceptance-tests",
-     "-J-Dmicroservice.services.access-control.endpoint.validate.allow-list.1=some-upstream-service",
-     "-J-Dmicroservice.services.access-control.endpoint.validate.allow-list.2=bank-account-reputation-frontend"
-     ],
-     "BANK_ACCOUNT_REPUTATION_THIRD_PARTY_CACHE": [
-     "-J-Dcontrollers.confidenceLevel.uk.gov.hmrc.bankaccountreputationthirdpartycache.controllers.CacheController.needsLogging=true"
-     ],
-     "BANK_ACCOUNT_REPUTATION_FRONTEND": [
-     "-J-Dauditing.enabled=true",
-     "-J-Dauditing.consumer.baseUri.port=6001",
-     "-J-Dauditing.consumer.baseUri.host=localhost"
-     ]
-     }'
+      "BANK_ACCOUNT_REPUTATION": [
+        "-Dplay.http.router=testOnlyDoNotUseInAppConf.Routes",
+        "-Dmicroservice.services.modulr.protocol=http",
+        "-Dmicroservice.services.modulr.host=localhost",
+        "-Dmicroservice.services.modulr.port=6001",
+        "-Dmicroservice.services.modulr.enabled=true",
+        "-Dmicroservice.services.modulr.business.cache.enabled=false",
+        "-Dmicroservice.services.modulr.personal.cache.enabled=false",
+        "-Dauditing.consumer.baseUri.port=6001",
+        "-Dauditing.consumer.baseUri.host=localhost",
+        "-Dauditing.enabled=true",
+        "-Dproxy.proxyRequiredForThisEnvironment=false",
+        "-Dmicroservice.services.eiscd.aws.endpoint=http://0.0.0.0:6002",
+        "-Dmicroservice.services.eiscd.aws.bucket=txm-dev-bacs-eiscd",
+        "-Dmicroservice.services.eiscd.cache-schedule.initial-delay=86400",
+        "-Dmicroservice.services.modcheck.cache-schedule.initial-delay=86400",
+        "-Dmicroservice.services.thirdPartyCache.endpoint=http://localhost:9899/cache",
+        "-Dmicroservice.services.access-control.endpoint.verify.enabled=true",
+        "-Dmicroservice.services.access-control.endpoint.verify.allow-list.0=bars-acceptance-tests",
+        "-Dmicroservice.services.access-control.endpoint.verify.allow-list.1=some-upstream-service",
+        "-Dmicroservice.services.access-control.endpoint.verify.allow-list.2=bank-account-reputation-frontend",
+        "-Dmicroservice.services.access-control.endpoint.verify.allow-list.3=bank-account-verification-frontend",
+        "-Dmicroservice.services.access-control.endpoint.validate.enabled=true",
+        "-Dmicroservice.services.access-control.endpoint.validate.allow-list.0=bars-acceptance-tests",
+        "-Dmicroservice.services.access-control.endpoint.validate.allow-list.1=some-upstream-service",
+        "-Dmicroservice.services.access-control.endpoint.validate.allow-list.2=bank-account-reputation-frontend",
+        "-Dmicroservice.services.access-control.endpoint.validate.allow-list.3=bank-account-verification-frontend",
+        "-Dmicroservice.services.modcheck.useLocal=true"
+      ],
+      "BANK_ACCOUNT_REPUTATION_THIRD_PARTY_CACHE": [
+        "-Dcontrollers.confidenceLevel.uk.gov.hmrc.bankaccountreputationthirdpartycache.controllers.CacheController.needsLogging=true"
+      ],
+      "BANK_ACCOUNT_VERIFICATION_FRONTEND": [
+        "-Dmicroservice.hosts.allowList.1=localhost",
+        "-Dauditing.consumer.baseUri.port=6001",
+        "-Dauditing.consumer.baseUri.host=localhost",
+        "-Dauditing.enabled=true",
+        "-Dmicroservice.services.access-control.enabled=true",
+        "-Dmicroservice.services.access-control.allow-list.0=bavfe-acceptance-tests"
+      ],
+      "BANK_ACCOUNT_REPUTATION_FRONTEND": [
+        "-Dauditing.enabled=true",
+        "-Dauditing.consumer.baseUri.port=6001",
+        "-Dauditing.consumer.baseUri.host=localhost"
+      ]
+    }'
+
+There is also a `.start_services.sh` script that you can run to start the services with the required configuration.
 
 Then execute the `run_tests.sh` script:
 

--- a/start_services.sh
+++ b/start_services.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -e
+
+sm2 --start BANK_ACCOUNT_REPUTATION_FRONTEND_SERVICES --appendArgs '{
+  "BANK_ACCOUNT_REPUTATION": [
+    "-Dplay.http.router=testOnlyDoNotUseInAppConf.Routes",
+    "-Dmicroservice.services.modulr.protocol=http",
+    "-Dmicroservice.services.modulr.host=localhost",
+    "-Dmicroservice.services.modulr.port=6001",
+    "-Dmicroservice.services.modulr.enabled=true",
+    "-Dmicroservice.services.modulr.business.cache.enabled=false",
+    "-Dmicroservice.services.modulr.personal.cache.enabled=false",
+    "-Dauditing.consumer.baseUri.port=6001",
+    "-Dauditing.consumer.baseUri.host=localhost",
+    "-Dauditing.enabled=true",
+    "-Dproxy.proxyRequiredForThisEnvironment=false",
+    "-Dmicroservice.services.eiscd.aws.endpoint=http://0.0.0.0:6002",
+    "-Dmicroservice.services.eiscd.aws.bucket=txm-dev-bacs-eiscd",
+    "-Dmicroservice.services.eiscd.cache-schedule.initial-delay=86400",
+    "-Dmicroservice.services.modcheck.cache-schedule.initial-delay=86400",
+    "-Dmicroservice.services.thirdPartyCache.endpoint=http://localhost:9899/cache",
+    "-Dmicroservice.services.access-control.endpoint.verify.enabled=true",
+    "-Dmicroservice.services.access-control.endpoint.verify.allow-list.0=bars-acceptance-tests",
+    "-Dmicroservice.services.access-control.endpoint.verify.allow-list.1=some-upstream-service",
+    "-Dmicroservice.services.access-control.endpoint.verify.allow-list.2=bank-account-reputation-frontend",
+    "-Dmicroservice.services.access-control.endpoint.verify.allow-list.3=bank-account-verification-frontend",
+    "-Dmicroservice.services.access-control.endpoint.validate.enabled=true",
+    "-Dmicroservice.services.access-control.endpoint.validate.allow-list.0=bars-acceptance-tests",
+    "-Dmicroservice.services.access-control.endpoint.validate.allow-list.1=some-upstream-service",
+    "-Dmicroservice.services.access-control.endpoint.validate.allow-list.2=bank-account-reputation-frontend",
+    "-Dmicroservice.services.access-control.endpoint.validate.allow-list.3=bank-account-verification-frontend",
+    "-Dmicroservice.services.modcheck.useLocal=true"
+  ],
+  "BANK_ACCOUNT_REPUTATION_THIRD_PARTY_CACHE": [
+    "-Dcontrollers.confidenceLevel.uk.gov.hmrc.bankaccountreputationthirdpartycache.controllers.CacheController.needsLogging=true"
+  ],
+  "BANK_ACCOUNT_VERIFICATION_FRONTEND": [
+    "-Dmicroservice.hosts.allowList.1=localhost",
+    "-Dauditing.consumer.baseUri.port=6001",
+    "-Dauditing.consumer.baseUri.host=localhost",
+    "-Dauditing.enabled=true",
+    "-Dmicroservice.services.access-control.enabled=true",
+    "-Dmicroservice.services.access-control.allow-list.0=bavfe-acceptance-tests"
+  ],
+  "BANK_ACCOUNT_REPUTATION_FRONTEND": [
+    "-Dauditing.enabled=true",
+    "-Dauditing.consumer.baseUri.port=6001",
+    "-Dauditing.consumer.baseUri.host=localhost"
+  ]
+}'


### PR DESCRIPTION
- Tried running these locally using the Readme but it didn't work
- Checked the `build-job` in Jenkins, and saw that it was using different config args when starting via SM. 
- Updated the readme and added a script with the same arguments as Jenkins, and then the tests ran and worked successfully 🟢 